### PR TITLE
Public TCP Framing Mode

### DIFF
--- a/Sources/OSCKit/TCP/Client/OSCTCPClient.swift
+++ b/Sources/OSCKit/TCP/Client/OSCTCPClient.swift
@@ -25,7 +25,6 @@ public final class OSCTCPClient {
     let tcpSocket: GCDAsyncSocket
     let tcpDelegate: OSCTCPClientDelegate
     let queue: DispatchQueue
-    let framingMode: OSCTCPFramingMode
     var receiveHandler: OSCHandlerBlock?
     var notificationHandler: NotificationHandlerBlock?
     
@@ -46,6 +45,9 @@ public final class OSCTCPClient {
     
     /// Returns a boolean indicating whether the OSC socket is connected to the remote host.
     public var isConnected: Bool { tcpSocket.isConnected }
+    
+    /// TCP packet framing mode.
+    public let framingMode: OSCTCPFramingMode
     
     /// Initialize with a remote hostname and UDP port.
     /// 

--- a/Sources/OSCKit/TCP/Server/OSCTCPServer.swift
+++ b/Sources/OSCKit/TCP/Server/OSCTCPServer.swift
@@ -26,7 +26,6 @@ public final class OSCTCPServer {
     let tcpSocket: GCDAsyncSocket
     let tcpDelegate: OSCTCPServerDelegate
     let queue: DispatchQueue
-    let framingMode: OSCTCPFramingMode
     var receiveHandler: OSCHandlerBlock?
     var notificationHandler: NotificationHandlerBlock?
     
@@ -48,6 +47,9 @@ public final class OSCTCPServer {
     /// Returns a boolean indicating whether the OSC server has been started.
     public private(set) var isStarted: Bool = false
     
+    /// TCP packet framing mode.
+    public let framingMode: OSCTCPFramingMode
+
     /// Initialize with a remote hostname and UDP port.
     /// 
     /// > Note:


### PR DESCRIPTION
Exposes `framingMode` as public on `OSCTCPServer` and `OSCTCPClient` to implementors.

This is a useful addition when implementors wish to query existing server or client settings to understand whether the server needs to be reinitialized with new configuration. `framingMode` is a user space property along with interface, port and host, so should also be visible to implementations.