### PR TITLE
Add OSCUDPServer Port Reuse

### DIFF
--- a/Sources/OSCKit/UDP/Server/OSCUDPServer.swift
+++ b/Sources/OSCKit/UDP/Server/OSCUDPServer.swift
@@ -34,6 +34,15 @@ public final class OSCUDPServer {
     /// Network interface to restrict connections to.
     public private(set) var interface: String?
     
+    /// Enable local UDP port reuse by other processes.
+    /// This property must be set prior to calling ``start()`` in order to take effect.
+    ///
+    /// By default, only one socket can be bound to a given IP address & port combination at a time. To enable
+    /// multiple processes to simultaneously bind to the same address & port, you need to enable
+    /// this functionality in the socket. All processes that wish to use the address & port
+    /// simultaneously must all enable reuse port on the socket bound to that port.
+    public var isPortReuseEnabled: Bool = false
+    
     /// Returns a boolean indicating whether the OSC server has been started.
     public private(set) var isStarted: Bool = false
     
@@ -50,6 +59,7 @@ public final class OSCUDPServer {
     ///   - port: Local port to listen on for inbound OSC packets.
     ///     If `nil` or `0`, a random available port in the system will be chosen.
     ///   - interface: Optionally specify a network interface for which to constrain communication.
+    ///   - isPortReuseEnabled: Enable local UDP port reuse by other processes.
     ///   - timeTagMode: OSC TimeTag mode. (Default is recommended.)
     ///   - queue: Optionally supply a custom dispatch queue for receiving OSC packets and dispatching the
     ///     handler callback closure. If `nil`, a dedicated internal background queue will be used.
@@ -57,12 +67,14 @@ public final class OSCUDPServer {
     public init(
         port: UInt16? = 8000,
         interface: String? = nil,
+        isPortReuseEnabled: Bool = false,
         timeTagMode: OSCTimeTagMode = .ignore,
         queue: DispatchQueue? = nil,
         receiveHandler: OSCHandlerBlock? = nil
     ) {
         _localPort = (port == nil || port == 0) ? nil : port
         self.interface = interface
+        self.isPortReuseEnabled = isPortReuseEnabled
         self.timeTagMode = timeTagMode
         let queue = queue ?? DispatchQueue(label: "com.orchetect.OSCKit.OSCUDPServer.queue")
         self.queue = queue
@@ -84,6 +96,7 @@ extension OSCUDPServer {
         
         stop()
         
+        try udpSocket.enableReusePort(isPortReuseEnabled)
         try udpSocket.bind(
             toPort: _localPort ?? 0, // 0 causes system to assign random open port
             interface: interface

--- a/Sources/OSCKit/UDP/Server/OSCUDPServer.swift
+++ b/Sources/OSCKit/UDP/Server/OSCUDPServer.swift
@@ -41,6 +41,10 @@ public final class OSCUDPServer {
     /// multiple processes to simultaneously bind to the same address & port, you need to enable
     /// this functionality in the socket. All processes that wish to use the address & port
     /// simultaneously must all enable reuse port on the socket bound to that port.
+    ///
+    /// Due to limitations of `SO_REUSEPORT` on Apple platforms, enabling this only permits receipt of broadcast
+    /// or multicast messages for any additional sockets which bind to the same address and port. Unicast
+    /// messages are only received by the first socket to bind.
     public var isPortReuseEnabled: Bool = false
     
     /// Returns a boolean indicating whether the OSC server has been started.
@@ -59,7 +63,7 @@ public final class OSCUDPServer {
     ///   - port: Local port to listen on for inbound OSC packets.
     ///     If `nil` or `0`, a random available port in the system will be chosen.
     ///   - interface: Optionally specify a network interface for which to constrain communication.
-    ///   - isPortReuseEnabled: Enable local UDP port reuse by other processes.
+    ///   - isPortReuseEnabled: Enable local UDP port reuse by other processes to receive broadcast packets.
     ///   - timeTagMode: OSC TimeTag mode. (Default is recommended.)
     ///   - queue: Optionally supply a custom dispatch queue for receiving OSC packets and dispatching the
     ///     handler callback closure. If `nil`, a dedicated internal background queue will be used.

--- a/Tests/OSCKitTests/UDP/Object Access Tests.swift
+++ b/Tests/OSCKitTests/UDP/Object Access Tests.swift
@@ -33,6 +33,8 @@ import Testing
         _ = oscServer.isStarted
         _ = oscServer.localPort
         // oscServer.localPort = 9000 // immutable actor
+        oscServer.isPortReuseEnabled = true
+        oscServer.isPortReuseEnabled = false
         oscServer.setReceiveHandler { message, timeTag, host, port in
             print(message)
         }


### PR DESCRIPTION
Adds support for UDP port reuse (SO_REUSEPORT) for OSCUDPServer, using `isPortReuseEnabled`.

This adds partity with OSCUDPClient and is a useful addition when implementors wish to have multiple servers sharing a port on the same machine.